### PR TITLE
PFBA: Fix some remaining flickering borders

### DIFF
--- a/pfba/gui/gui.cpp
+++ b/pfba/gui/gui.cpp
@@ -673,10 +673,6 @@ void Gui::Run() {
             } else if (key & Input::Key::KEY_FIRE1) {
                 if (romSelected != NULL
                     && romSelected->state != RomList::RomState::MISSING) {
-                    for (int i = 0; i < 6; i++) {
-                        Clear();
-                        Flip();
-                    }
                     RunRom(romSelected);
                 }
             } else if (key & Input::Key::KEY_MENU1) {

--- a/pfba/run.cpp
+++ b/pfba/run.cpp
@@ -330,6 +330,16 @@ void RunEmulator(Gui *g, int drvnum) {
     StartTicks(); // no frameskip
 
     GameLooping = true;
+    
+    // prevent flickering borders by rendering a few frames and
+    // blanking the display afterwards
+    for (int i = 0; i < 9; i++)
+        RunOneFrame(true, 0, 0);
+    for (int i = 0; i < 3; i++) {
+        video->Clear();
+        video->Flip();
+    }
+    
     while (GameLooping) {
 
         int showFps = gui->GetConfig()->GetRomValue(Option::Index::ROM_SHOW_FPS);


### PR DESCRIPTION
The borders flickered when loading a neogeo rom, unibios was enabled, and neogeo.zip didn't contain uni-bios_3_2.rom.

My only explanation is that there is some bug in vita2d where some texture is not cleared when it should. This workaround fixes that problem.